### PR TITLE
Fix problem with huge files

### DIFF
--- a/libs/libjson/_internal/Source/JSONNode.h
+++ b/libs/libjson/_internal/Source/JSONNode.h
@@ -161,7 +161,7 @@ public:
 
 
     json_string as_string(void) const json_nothrow json_read_priority;
-    int as_int(void) const json_nothrow json_read_priority;
+    json_int_t as_int(void) const json_nothrow json_read_priority;
     json_number as_float(void) const json_nothrow json_read_priority;
     bool as_bool(void) const json_nothrow json_read_priority;
     
@@ -666,9 +666,9 @@ inline void JSONNode::set_name(const json_string & newname) json_nothrow{
 	   return static_cast<json_string>(*internal);
     }
 
-    inline int JSONNode::as_int(void) const json_nothrow {
+    inline json_int_t JSONNode::as_int(void) const json_nothrow {
 	   JSON_CHECK_INTERNAL();
-	   return static_cast<int>(*internal);
+	   return static_cast<json_int_t>(*internal);
     }
 
     inline json_number JSONNode::as_float(void) const json_nothrow {

--- a/libs/libjson/_internal/Source/internalJSONNode.h
+++ b/libs/libjson/_internal/Source/internalJSONNode.h
@@ -156,8 +156,8 @@ public:
 	   DECL_CAST_OP(short)
 	   DECL_CAST_OP(int)
 	   DECL_CAST_OP(long)
+	   DECL_CAST_OP(long long)
 	   #ifndef JSON_ISO_STRICT
-		  DECL_CAST_OP(long long)
 		  operator long double() const json_nothrow;
 	   #endif
 	   operator float() const json_nothrow;
@@ -466,11 +466,9 @@ inline JSONNode * internalJSONNode::at(json_index_t pos) json_nothrow {
     IMP_SMALLER_INT_CAST_OP(unsigned short, USHRT_MAX, 0)
     IMP_SMALLER_INT_CAST_OP(int, INT_MAX, INT_MIN)
     IMP_SMALLER_INT_CAST_OP(unsigned int, UINT_MAX, 0)
+    IMP_SMALLER_INT_CAST_OP(long long, LLONG_MAX, LLONG_MIN)
+    IMP_SMALLER_INT_CAST_OP(unsigned long long, ULLONG_MAX, 0)
 
-    #ifndef JSON_ISO_STRICT
-	   IMP_SMALLER_INT_CAST_OP(long, LONG_MAX, LONG_MIN)
-	   IMP_SMALLER_INT_CAST_OP(unsigned long, ULONG_MAX, 0)
-    #endif
 #endif
 
 inline internalJSONNode::operator json_string() const json_nothrow {

--- a/src/serializer/CentralizedFileFormat.cpp
+++ b/src/serializer/CentralizedFileFormat.cpp
@@ -111,7 +111,7 @@ void CentralizedFileFormat::CleanTables()
     pOffsetTable_->Cleanup();
 }
 
-int CentralizedFileFormat::OpenStreamAppend(std::ofstream& stream, const std::string& fieldName, const Savepoint&) const
+OffsetTable::offset_t CentralizedFileFormat::OpenStreamAppend(std::ofstream& stream, const std::string& fieldName, const Savepoint&) const
 {
     // Discard savepoint because we are just appending data to the file
 

--- a/src/serializer/CentralizedFileFormat.cpp
+++ b/src/serializer/CentralizedFileFormat.cpp
@@ -129,10 +129,13 @@ void CentralizedFileFormat::OpenStreamRead(std::ifstream& stream, const std::str
     fname << directory_ << "/" << prefix_ << "_" << fieldName << ".dat";
 
     // Check if field is already saved at savepoint and get offset
-    const int offset = pOffsetTable_->GetOffset(savepoint, fieldName);
-    if (offset < 0)
+    OffsetTable::offset_t offset;
+    try {
+        offset = pOffsetTable_->GetOffset(savepoint, fieldName);
+    }
+    catch (SerializationException)
     {
-        // Throw exception
+        // Throw more detailed exception
         std::ostringstream errorstr;
         errorstr << "Error: field " << fieldName << " is not saved into serializer "
             << "at savepoint " << savepoint.ToString();

--- a/src/serializer/CentralizedFileFormat.h
+++ b/src/serializer/CentralizedFileFormat.h
@@ -42,7 +42,7 @@ namespace ser {
 
         virtual void CleanTables();
 
-        virtual int OpenStreamAppend(std::ofstream& stream, const std::string& fieldName, const Savepoint& savepoint) const;
+        virtual OffsetTable::offset_t OpenStreamAppend(std::ofstream& stream, const std::string& fieldName, const Savepoint& savepoint) const;
 
         virtual void OpenStreamRead(std::ifstream& stream, const std::string& fieldName, const Savepoint& savepoint) const;
 

--- a/src/serializer/FileFormat.h
+++ b/src/serializer/FileFormat.h
@@ -4,6 +4,7 @@
 //See LICENSE.txt for more information
 
 #include <string>
+#include "OffsetTable.h"
 
 namespace ser {
 
@@ -53,7 +54,7 @@ namespace ser {
         *
         * @return The offset from the beginning of the file is returned
         */
-        virtual int OpenStreamAppend(std::ofstream& stream, const std::string& fieldName, const Savepoint& savepoint) const =0;
+        virtual OffsetTable::offset_t OpenStreamAppend(std::ofstream& stream, const std::string& fieldName, const Savepoint& savepoint) const =0;
 
         /**
         * Opens a stream for reading data

--- a/src/serializer/OffsetTable.cpp
+++ b/src/serializer/OffsetTable.cpp
@@ -148,7 +148,7 @@ OffsetTable::offset_t OffsetTable::GetOffset(int savepointID, const std::string&
     return iter->second.offset;
 }
 
-int OffsetTable::AlreadySerialized(const std::string& fieldName, const std::string& checksum) const
+bool OffsetTable::AlreadySerialized(const std::string& fieldName, const std::string& checksum, OffsetTable::offset_t& offset) const
 {
     // Loop backwards
     for (std::vector<OffsetTableEntry>::const_reverse_iterator iter = entries_.rbegin(); iter != entries_.rend(); ++iter)
@@ -157,9 +157,12 @@ int OffsetTable::AlreadySerialized(const std::string& fieldName, const std::stri
         if (entry == iter->end())
             continue;
         if (entry->second.checksum == checksum)
-            return entry->second.offset;
+        {
+            offset = entry->second.offset;
+            return true;
+        }
     }
-    return -1;
+    return false;
 }
 
 std::string OffsetTable::ToString() const
@@ -277,7 +280,7 @@ void OffsetTable::TableFromJSON(const JSONNode& node)
         // Interpret offsets and add records
         for (JSONNode::const_iterator o_iter = offsetsnode.begin(); o_iter != offsetsnode.end(); ++o_iter)
         {
-            int offset = (*o_iter)[0].as_int();
+            const offset_t offset = (*o_iter)[0].as_int();
             const std::string checksum = (*o_iter)[1].as_string();
             AddFieldRecord(savepointID, o_iter->name(), offset, checksum);
         }

--- a/src/serializer/OffsetTable.h
+++ b/src/serializer/OffsetTable.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #include "Savepoint.h"
 
@@ -22,8 +23,11 @@ namespace ser{
     */
     class OffsetTable
     {
-        typedef int offset_t;
+    public:
+        typedef std::uint64_t offset_t;
         typedef std::string checksum_t;
+
+    private:
         typedef struct { offset_t offset; checksum_t checksum; } OffsetTableEntryValue;
         typedef std::map<std::string, OffsetTableEntryValue> OffsetTableEntry;
         typedef OffsetTableEntry::const_iterator const_iterator;
@@ -87,15 +91,15 @@ namespace ser{
         * is returned, but no exception is thrown.
         *
         * @throw SerializationException The savepoint is not registered in the table
+        *        or the the specified field is not registered at the given savepoint
         *
         * @param savepoint Guess what...
         * @param fieldName Idem
         *
-        * @return The offset is returned if the record is found, otherwise a negative
-        * value is returned.
+        * @return The offset is returned if the record is found.
         */
-        int GetOffset(const Savepoint& savepoint, const std::string& fieldName) const;
-        int GetOffset(int savepointID, const std::string& fieldName) const;
+        offset_t GetOffset(const Savepoint& savepoint, const std::string& fieldName) const;
+        offset_t GetOffset(int savepointID, const std::string& fieldName) const;
 
         /**
         * Checks if an entry of the field with the same checksum exists. This can be used

--- a/src/serializer/OffsetTable.h
+++ b/src/serializer/OffsetTable.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <string>
 #include <cstdint>
+#include <ios>
 
 #include "Savepoint.h"
 
@@ -24,7 +25,7 @@ namespace ser{
     class OffsetTable
     {
     public:
-        typedef std::uint64_t offset_t;
+        typedef std::streamoff offset_t;
         typedef std::string checksum_t;
 
     private:

--- a/src/serializer/OffsetTable.h
+++ b/src/serializer/OffsetTable.h
@@ -104,14 +104,16 @@ namespace ser{
         /**
         * Checks if an entry of the field with the same checksum exists. This can be used
         * to avoid storing to the disk if the same state of a field is already stored.
+        * In case the record is found, the corresponding offset will be stored in the
+        * given variable, otherwise its value is not modified.
         *
         * @param fieldName The name of the field
         * @param checksum The checksum of the content
+        * @param[out] offset The offset of the found record, if any, is stored here
         *
-        * @return The offset of the already serialized field is returned if found.
-        *         Otherwise, a negative value is returned.
+        * @return True is returned iff a record is found
         */
-        int AlreadySerialized(const std::string& fieldName, const std::string& checksum) const;
+        bool AlreadySerialized(const std::string& fieldName, const std::string& checksum, offset_t& offset) const;
 
         /**
         * Produces a string represetation of the table

--- a/src/serializer/OffsetTable.h
+++ b/src/serializer/OffsetTable.h
@@ -6,7 +6,6 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <cstdint>
 #include <ios>
 
 #include "Savepoint.h"

--- a/src/serializer/Serializer.cpp
+++ b/src/serializer/Serializer.cpp
@@ -192,11 +192,11 @@ void Serializer::WriteField(const std::string& fieldName, const Savepoint& savep
             info.iSize(), info.jSize(), info.kSize(), info.lSize(),
             iStride, jStride, kStride, lStride, binaryData);
 
-    // Control in offset table if data must be stored
-    int offset = offsetTable_.AlreadySerialized(fieldName, checksum);
-
-    if (offset < 0)
+    // Check in offset table if data must be stored
+    OffsetTable::offset_t offset;
+    if (!offsetTable_.AlreadySerialized(fieldName, checksum, offset))
     {
+        // Record is not found: we need to write the data
         // Open file stream
         std::ofstream fs;
         offset = pFileFormat_->OpenStreamAppend(fs, fieldName, savepoint);

--- a/src/serializer/Serializer.cpp
+++ b/src/serializer/Serializer.cpp
@@ -168,15 +168,22 @@ void Serializer::WriteField(const std::string& fieldName, const Savepoint& savep
         savepointID = offsetTable_.AddNewSavepoint(savepoint);
 
     // Check if field is already saved at savepoint
-    if (offsetTable_.GetOffset(savepointID, fieldName) >= 0)
+    try
     {
-        // Throw exception
+        offsetTable_.GetOffset(savepointID, fieldName);
+
+        // Field is already there: throw exception
         std::ostringstream errorstr;
         errorstr << "Error: field " << fieldName << " was already saved into "
             << "serializer at savepoint " << savepoint.ToString();
         SerializationException exception;
         exception.Init(errorstr.str());
         throw exception;
+    }
+    catch (SerializationException&)
+    {
+        // Field is not there (or savepoint does not exist)
+        // No error, continue
     }
 
     // Obtain buffer and checksum
@@ -233,8 +240,26 @@ void Serializer::ReadField(const std::string& fieldName, const Savepoint& savepo
     // Search in previous savepoints
     if (alsoPrevious)
     {
-        while(savepointID >= 0 && offsetTable_.GetOffset(savepointID, fieldName) < 0)
-            --savepointID;
+        OffsetTable::offset_t offset;
+        bool found = false;
+        while(!found)
+        {
+            try
+            {
+                offsetTable_.GetOffset(savepointID, fieldName);
+
+                // Field is found
+                found = true;
+                break;
+            }
+            catch (SerializationException&)
+            {
+                // Field is not found: proceed with previous savepoint
+            }
+
+            if(--savepointID < 0)
+                break;
+        }
 
         if (savepointID < 0)
         {

--- a/unittest/serializer/OffsetTableUnittest.cpp
+++ b/unittest/serializer/OffsetTableUnittest.cpp
@@ -79,18 +79,21 @@ TEST_F(OffsetTableUnittest, Checksum)
     OffsetTable table;
     table.AddNewSavepoint(sp0, 0);
     table.AddNewSavepoint(sp1, 1);
-    int offset;
+    OffsetTable::offset_t offset;
 
-    ASSERT_EQ(-1, offset = table.AlreadySerialized("Field1", computeChecksum(data, 4)));
+    ASSERT_FALSE(table.AlreadySerialized("Field1", computeChecksum(data, 4), offset));
     ASSERT_NO_THROW(table.AddFieldRecord(0, "Field1",   0, computeChecksum(data, 4)));
-    ASSERT_EQ(-1, offset = table.AlreadySerialized("Field1", computeChecksum(data, 8)));
+    ASSERT_FALSE(table.AlreadySerialized("Field1", computeChecksum(data, 8), offset));
     ASSERT_NO_THROW(table.AddFieldRecord(1, "Field1", 100, computeChecksum(data, 8)));
-    ASSERT_EQ(-1, offset = table.AlreadySerialized("Field2", computeChecksum(data, 8)));
+    ASSERT_FALSE(table.AlreadySerialized("Field2", computeChecksum(data, 8), offset));
     ASSERT_NO_THROW(table.AddFieldRecord(0, "Field2", 200, computeChecksum(data, 8)));
 
-    ASSERT_EQ(  0, table.AlreadySerialized("Field1", computeChecksum(data,4)));
-    ASSERT_EQ(100, table.AlreadySerialized("Field1", computeChecksum(data,8)));
-    ASSERT_EQ(200, table.AlreadySerialized("Field2", computeChecksum(data,8)));
+    ASSERT_TRUE(table.AlreadySerialized("Field1", computeChecksum(data, 4), offset));
+    ASSERT_EQ(0, offset);
+    ASSERT_TRUE(table.AlreadySerialized("Field1", computeChecksum(data, 8), offset));
+    ASSERT_EQ(100, offset);
+    ASSERT_TRUE(table.AlreadySerialized("Field2", computeChecksum(data, 8), offset));
+    ASSERT_EQ(200, offset);
     ASSERT_NO_THROW(table.AddFieldRecord(1, "Field2", 200, computeChecksum(data, 8)));
 
     ASSERT_EQ(  0, table.GetOffset(sp0, "Field1"));
@@ -165,15 +168,20 @@ TEST_F(OffsetTableUnittest, TableToJSON)
     ASSERT_EQ(1, table2.GetSavepointID(sp[1]));
 
     // Check methods
+    OffsetTable::offset_t offset;
     ASSERT_EQ(  0, table2.GetOffset(sp0, "Field1"));
     ASSERT_EQ(  0, table2.GetOffset(sp0, "Field2"));
     ASSERT_EQ(100, table2.GetOffset(sp1, "Field1"));
     ASSERT_EQ(100, table2.GetOffset(sp1, "Field2"));
-    ASSERT_EQ(  0, table2.AlreadySerialized("Field1", computeChecksum(somedata, 4)));
-    ASSERT_EQ(100, table2.AlreadySerialized("Field1", computeChecksum(somedata, 12)));
-    ASSERT_EQ(  0, table2.AlreadySerialized("Field2", computeChecksum(somedata, 8)));
-    ASSERT_EQ(100, table2.AlreadySerialized("Field2", computeChecksum(somedata, 16)));
-    ASSERT_EQ( -1, table2.AlreadySerialized("Field1", computeChecksum(somedata, 8)));
-    ASSERT_EQ( -1, table2.AlreadySerialized("Field2", computeChecksum(somedata, 4)));
+    ASSERT_TRUE(table2.AlreadySerialized("Field1", computeChecksum(somedata, 4), offset));
+    ASSERT_EQ(  0, offset);
+    ASSERT_TRUE(table2.AlreadySerialized("Field1", computeChecksum(somedata, 12), offset));
+    ASSERT_EQ(100, offset);
+    ASSERT_TRUE(table2.AlreadySerialized("Field2", computeChecksum(somedata, 8), offset));
+    ASSERT_EQ(  0, offset);
+    ASSERT_TRUE(table2.AlreadySerialized("Field2", computeChecksum(somedata, 16), offset));
+    ASSERT_EQ(100, offset);
+    ASSERT_FALSE(table2.AlreadySerialized("Field1", computeChecksum(somedata, 8), offset));
+    ASSERT_FALSE(table2.AlreadySerialized("Field2", computeChecksum(somedata, 4), offset));
 }
 


### PR DESCRIPTION
With this patch, serialbox should be able to handle flawlessly any file supported by the operating system. This works by using the `OffsetTable::offset_t` type instead of `int`. `offset_t` is a typedef to `std::streamoff`

See http://stackoverflow.com/questions/24437016/is-stdstreampos-guaranteed-to-be-unsigned-long-long.

> The type std::streamoff is a signed integral type of sufficient size to represent the maximum possible file size supported by the operating system.

The only way `offset_t` variables interact with other functions is through `std::seekg` (as a parameter) and through `std::tellp` (as return value). Both functions operate with `std::streampos`, which is a class type consistently convertible from and to `std::streamoff` (see http://www.cplusplus.com/reference/ios/streampos/). The only other interaction is with JSON (conversion from and to `JSON_INT_TYPE`, which is `long long`). If we want to be very picky, we should also modify `libs/libjson/JSONOptions.h` to define `JSON_INT_TYPE` to be `std::streamoff`, but `long long` will suffice in all our cases.
