### PR TITLE
Add equals operator to Savepoint in Python API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/fortran/ DESTINATION include/fortran FILES
 if (CMAKE_VERSION VERSION_LESS "3.1")
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Cray")
         set (CMAKE_CXX_FLAGS "-h std=c++11 ${CMAKE_CXX_FLAGS}")
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "PGI")
+        set (CMAKE_CXX_FLAGS "--c++11 ${CMAKE_CXX_FLAGS}")
     else()
          set (CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
     endif()

--- a/python/serialbox/serialization.py
+++ b/python/serialbox/serialization.py
@@ -292,6 +292,9 @@ class Savepoint(object):
     def __str__(self):
         return self.name + '[ ' + ' '.join(['{0}:{1}'.format(*i) for i in self.metainfo.items()]) + ' ]'
 
+    def __eq__(self, other):
+        return self.name == other.name and self.metainfo == other.metainfo
+
     @property
     def name(self):
         namelength = fs_savepoint_name_length(self.savepoint)


### PR DESCRIPTION
After this commit the expression "sp1 == sp2" will return True for any
couple of savepoints whose name and metainfo match. Before this the
expression returned False if sp1 and sp2 were not the same object.

This also enables for checking if a copy of a savepoint can be found in
a list. For instance, if ser1 and ser2 are two independent serializers,
the following expression will now check if the first savepoint in ser1
can be found in ser2 as well:

    ser1.savepoints[0] in ser2.savepoints